### PR TITLE
fix number 1_000_000 and larger

### DIFF
--- a/lib/extensobr.rb
+++ b/lib/extensobr.rb
@@ -299,8 +299,8 @@ class Extenso
 
       # Chamada recursiva à função para processar resto se este for maior que zero.
       # O conectivo 'e' é utilizado entre milhões e números entre 1 e 99, bem como antes de centenas exatas.
-      if resto && ((resto >= 1 && resto <= 99) || resto % 100 == 0)
-        ret += ' e ' + ret.numero(resto, genero)
+      if resto && (resto >= 1 && resto <= 99)
+        ret += ' e ' + self.numero(resto, genero)
       # Nos demais casos, após o milhão é utilizada a vírgula.
       elsif resto > 0
         ret += ', ' + self.numero(resto, genero)


### PR DESCRIPTION
Erro gerado com valor 1.000.000 (Um Milhão) e números maiores.


Os valores abaixo geravam erro:

Valores: Extenso.numero(1000000) e Extenso.moeda(100000000)
Erro: NoMethodError: undefined method `numero' for "Um Milhão":String
from .rvm/gems/ruby-2.1.1@[rvm_name]/gems/extensobr-0.1.0/lib/extensobr.rb:303:in `numero'


Em **extensobr.rb:303** foi removido _|| resto % 100 == 0_, pois não era necessário e gerava o erro abaixo:

RuntimeError: [Exceção em Extenso.numero] Parâmetro 'valor' igual a ou menor que zero (recebido: '0') from .rvm/gems/ruby-2.1.1@[rvm_name]/gems/extensobr-0.1.0/lib/extensobr.rb:229:in `numero'